### PR TITLE
Fix: Corregido error de formato de fecha ValueError: Invalid isoforma…

### DIFF
--- a/pyDolarVenezuela/providers/criptodolar.py
+++ b/pyDolarVenezuela/providers/criptodolar.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 import json
 
 from .. import network
-from ..utils.time import get_formatted_date
+from ..utils.time import get_formatted_date, get_formatted_date_tz
 from ..utils.common import _convert_specific_format, _convert_dollar_name_to_monitor_name
 from ..utils.extras import list_monitors_images
 from ._base import Base
@@ -25,7 +25,7 @@ class CriptoDolar(Base):
                 title = _convert_dollar_name_to_monitor_name(monitor['name'])
                 price = round(monitor['price'], 2)
                 price_old   = monitor['priceOld']
-                last_update = get_formatted_date(monitor['updatedAt'])
+                last_update = get_formatted_date_tz(monitor['updatedAt'])
 
                 data.append({
                     'key': key,

--- a/pyDolarVenezuela/utils/time.py
+++ b/pyDolarVenezuela/utils/time.py
@@ -1,6 +1,6 @@
 from babel.dates import format_date, format_time
 from datetime import datetime, timedelta
-from pytz import timezone
+from pytz import timezone,utc
 
 from .extras import time_units
 
@@ -34,6 +34,19 @@ def get_formatted_date(date_string: str):
     Formatear datetime.
     """
     return datetime.fromisoformat(date_string).astimezone(standard_time_zone)
+
+
+def get_formatted_date_tz(date_string: str):
+    """
+    Formatear datetime desde TZ.
+    """
+    # Parsear la fecha y hora usando strptime
+    dt = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%fZ")
+    # Asignar la zona horaria UTC utilizando pytz
+    dt = dt.replace(tzinfo=utc)
+
+    return dt.astimezone(standard_time_zone)
+
 
 def get_time(date_string: str):
     """


### PR DESCRIPTION
Buenos dias, 

Al correr por ejemplo:
cripto = Monitor(CriptoDolar, 'USD') 
cripto.get_value_monitors("paypal")    

Estaba arrojando un error con el formato del string que no podía parsear bien. 
return datetime.fromisoformat(date_string).astimezone(standard_time_zone)
ValueError: Invalid isoformat string: '2024-09-12T05:15:02.801Z'

Como varios providers usan el método get_formatted_date() creé uno nuevo para tipos de fecha TZ, como  '2024-09-12T05:15:02.801Z', se corrige este error y queda el método para futuros string parecidos.


